### PR TITLE
Remove PHP short open tag <?

### DIFF
--- a/header.php
+++ b/header.php
@@ -68,7 +68,7 @@
 								alt="Header Image"
 					/>
 				</div>
-			<? endif; ?>
+			<?php endif; ?>
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">
 			<div class="col-lg-9 col-xs-7 primary-menu">


### PR DESCRIPTION
Convert a php short open tag to a normal open tag, to match the rest of the repo and avoid confusing errors when run on a config without short_open_tag enabled.